### PR TITLE
add title string file extension trim

### DIFF
--- a/internal/trim.go
+++ b/internal/trim.go
@@ -1,0 +1,14 @@
+package internal
+
+import "strings"
+
+func TrimExtension(s string) string {
+	idx := strings.LastIndex(s, ".pdf")
+
+	// No such file extension exists
+	if idx == -1 {
+		return s
+	}
+
+	return s[:idx]
+}

--- a/models/kendra.go
+++ b/models/kendra.go
@@ -5,6 +5,8 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/kendra"
+
+	"github.com/DSSD-Madison/gmu/internal"
 )
 
 var opts = kendra.Options{
@@ -33,7 +35,7 @@ func queryOutputToResults(out kendra.QueryOutput) KendraResults {
 
 	for _, item := range out.ResultItems {
 		res := KendraResult{
-			Title:   *item.DocumentTitle.Text,
+			Title:   internal.TrimExtension(*item.DocumentTitle.Text),
 			Excerpt: *item.DocumentExcerpt.Text,
 		}
 		results.Results = append(results.Results, res)


### PR DESCRIPTION
Adds a function for trimming the title of a query result. The function should be quite easy to extend to add more file extensions if needed.

Progress for #7