### PR TITLE
Use new templating structure

### DIFF
--- a/models/templates.go
+++ b/models/templates.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"html/template"
 	"io"
 
@@ -12,7 +13,17 @@ type Templates struct {
 }
 
 func (t *Templates) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
-	return t.templates[name].Execute(w, data)
+	tmpl, ok := t.templates[name]
+	if !ok {
+		return fmt.Errorf("template %s not found", name)
+	}
+
+	err := tmpl.Execute(w, data)
+	if err != nil {
+		return fmt.Errorf("failed to render template %s: %w", name, err)
+	}
+
+	return nil
 }
 
 func NewTemplate() *Templates {

--- a/models/templates.go
+++ b/models/templates.go
@@ -3,7 +3,6 @@ package models
 import (
 	"html/template"
 	"io"
-	"log"
 
 	"github.com/labstack/echo/v4"
 )
@@ -13,8 +12,6 @@ type Templates struct {
 }
 
 func (t *Templates) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
-	// DEBUG: REMOVE
-	log.Println("Rendering template:", name)
 	return t.templates[name].Execute(w, data)
 }
 

--- a/models/templates.go
+++ b/models/templates.go
@@ -3,20 +3,36 @@ package models
 import (
 	"html/template"
 	"io"
+	"log"
 
 	"github.com/labstack/echo/v4"
 )
 
 type Templates struct {
-	templates *template.Template
+	templates map[string]*template.Template
 }
 
 func (t *Templates) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
-	return t.templates.ExecuteTemplate(w, name, data)
+	// DEBUG: REMOVE
+	log.Println("Rendering template:", name)
+	return t.templates[name].Execute(w, data)
 }
 
 func NewTemplate() *Templates {
+	tmpl := make(map[string]*template.Template)
+	tmpl["index"] = template.Must(template.ParseFiles(
+		"views/index.html",
+		"views/search-home.html",
+	))
+	tmpl["search"] = template.Must(template.ParseFiles(
+		"views/search.html",
+	))
+	tmpl["results"] = template.Must(template.ParseFiles(
+		"views/results.html",
+		"views/sidecolumn.html",
+	))
+
 	return &Templates{
-		templates: template.Must(template.ParseGlob("views/*.html")),
+		templates: tmpl,
 	}
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -9,7 +9,7 @@ func InitRoutes(e *echo.Echo) {
 	// Home Route
 	e.GET("/", Home)
 
-	// Search Route
+	// Search Routes
 	e.POST("/fetchSearchPage", fetchSearchPage)
 	e.POST("/search", Search)
 }

--- a/routes/search.go
+++ b/routes/search.go
@@ -15,7 +15,7 @@ func fetchSearchPage(c echo.Context) error {
 	if len(query) < MinQueryLengh {
 		return c.String(http.StatusBadRequest, "Error 400, could not get query from request.")
 	}
-	return c.Render(http.StatusOK, "results-init", query)
+	return c.Render(http.StatusOK, "search", query)
 }
 
 func Search(c echo.Context) error {
@@ -24,5 +24,6 @@ func Search(c echo.Context) error {
 		return c.String(http.StatusBadRequest, "Error 400, could not get query from request.")
 	}
 	results := models.MakeQuery(query)
+
 	return c.Render(http.StatusOK, "results", results)
 }

--- a/views/book.html
+++ b/views/book.html
@@ -1,8 +1,0 @@
-<!-- Book Page -->
-{{ define "book-page" }}
-<div class="p-6">
-    <h2 class="text-2xl font-bold">{{ .Title }}</h2>
-    <p class="text-gray-700">{{ .Description }}</p>
-    <p class="text-sm text-gray-500">{{ .Id }}</p>
-</div>
-{{end}}

--- a/views/book.html
+++ b/views/book.html
@@ -1,5 +1,5 @@
 <!-- Book Page -->
-{{ block "book-page" . }}
+{{ define "book-page" }}
 <div class="p-6">
     <h2 class="text-2xl font-bold">{{ .Title }}</h2>
     <p class="text-gray-700">{{ .Description }}</p>

--- a/views/index.html
+++ b/views/index.html
@@ -1,19 +1,18 @@
 <!-- Page Boilerplate -->
-{{ block "index" . }}
 <!DOCTYPE html>
 <html lang="en" class="overscroll-none">
-<head>
-    <title></title>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <title>Better Evidence Project</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/images/logo.ico" type="image/x-icon">
     <script src="https://unpkg.com/htmx.org/dist/htmx.min.js"></script>
-    <link href="/css/output.css" rel="stylesheet">
-</head>
-<body class="m-0">
-<div id="root">
-    {{ template "search-home" . }}
-</div>
-</body>
+    <link href="/css/output.css" rel="stylesheet" />
+  </head>
+  <body class="m-0">
+    <div id="root">
+      {{ block "search-home" . }} Default content {{ end }}
+    </div>
+  </body>
 </html>
-{{end}}
 

--- a/views/results.html
+++ b/views/results.html
@@ -1,56 +1,17 @@
-<!-- Results Page -->
-{{ block "results-init" . }}
-<div class="relative h-[300px]">
-    <img src="images/Banner.jpeg" class="absolute top-0 w-full h-auto max-w-full z-[-1]">
-    <div
-        id="formwrapper"
-        hx-trigger="load"
-        hx-post="/search"
-        class="grid place-items-center h-full"
-        hx-include="#searchquery"
-        hx-target="#root"
-        hx-swap="innerHTML">
-        <form hx-post="/search">
-            <div id="searchbar" class="flex relative">
-                <input id="searchquery" class="border-2 border-gray-400 px-6 py-3 text-2xl w-full" type="text" name="query" value="{{ . }}">
-                {{ template "indicator" . }}
-            </div>
-        </form>
-    </div>
-</div>
-<div id="grid-container" class="grid grid-cols-[1fr_3fr] bg-white"></div>
-{{end}}
-
-{{ block "indicator" . }}
-<img id="indicator" src="svg/bars.svg" class="htmx-indicator inline absolute self-center right-8">
-{{end}}
-
 <!-- Results Section -->
-{{ block "results" . }}
-<div class="relative h-[300px]">
-    <img src="images/Banner.jpeg" class="absolute top-0 w-full h-auto max-w-full z-[-1]">
-    <div id="formwrapper" class="grid place-items-center h-full">
-        <form id="searchform" hx-post="/search">
-            <div id="searchbar" class="flex relative">
-                <input class="border-2 border-gray-400 px-6 py-3 text-2xl w-full" type="text" name="query" value="{{ .Query }}">
-                {{ template "indicator" . }}
-            </div>
-        </form>
-    </div>
-</div>
-
-<div id="grid-container" class="grid grid-cols-[1fr_3fr] bg-white">
+{{ block "results-list" . }}
+<div id="grid-container" class="grid grid-cols-[1fr_3fr] bg-white w-full">
     {{ template "sidecolumn-nohtmx" . }}
     <div id="results-container" class="space-y-6">
         {{ range .Results }}
-        {{ template "result" . }}
+        {{ template "result-card" . }}
         {{end}}
     </div>
 </div>
 {{end}}
 
 <!-- Individual Result Partial -->
-{{ block "result" . }}
+{{ define "result-card" }}
 <div class="flex items-start space-x-6 p-4">
     <div>
         <a href="{{ .Link }}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold underline">
@@ -60,4 +21,3 @@
     </div>
 </div>
 {{end}}
-

--- a/views/search-home.html
+++ b/views/search-home.html
@@ -1,5 +1,5 @@
-<!-- Search Page -->
-{{ block "search-home" . }}
+<!-- Home Page -->
+{{ define "search-home" }}
 <div class="flex flex-col items-center justify-center absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 space-y-4 p-6">
     <h2 class="text-xl font-semibold">Search</h2>
     <form hx-post="/fetchSearchPage" hx-swap="innerHTML" hx-target="#root">

--- a/views/search.html
+++ b/views/search.html
@@ -1,0 +1,23 @@
+<!-- Loading Indicator -->
+{{ block "indicator" . }}
+<img id="indicator" src="svg/bars.svg" class="htmx-indicator inline absolute self-center right-8">
+{{end}}
+
+
+<!-- Search Page -->
+{{ block "results-init" . }}
+<div class="relative h-[300px]">
+    <img src="images/Banner.jpeg" class="absolute top-0 w-full h-auto max-w-full z-[-1]">
+    <div id="formwrapper" class="grid place-items-center h-full">
+        <form hx-post="/search" hx-target="#results-container" hx-swap="innerHTML" hx-trigger="load">
+            <div id="searchbar" class="flex relative">
+                <input id="searchquery" class="border-2 border-gray-400 px-6 py-3 text-2xl w-full" type="text" name="query" value="{{ . }}">
+                {{ template "indicator" . }}
+            </div>
+        </form>
+    </div>
+    <div id="results-container">
+        <!-- Search results will be dynamically populated here -->
+    </div>
+</div>
+{{end}}

--- a/views/sidecolumn.html
+++ b/views/sidecolumn.html
@@ -1,5 +1,5 @@
 <!-- Filters Section -->
-{{ block "sidecolumn" . }}
+{{ define "sidecolumn" }}
 <div id="sidecolumn" class="mt-12 ml-12">
     <p>{{ .Count }} Results</p>
     <div class="flex flex-col space-y-2">
@@ -23,7 +23,7 @@
 </div>
 {{end}}
 
-{{ block "sidecolumn-nohtmx" . }}
+{{ define "sidecolumn-nohtmx" }}
 <div id="sidecolumn" class="mt-12 ml-12">
     <p>{{ .Count }} Results</p>
     <div class="flex items-center space-x-2">
@@ -34,4 +34,3 @@
     </div>
 </div>
 {{end}}
-


### PR DESCRIPTION
Add templating structure @bengoh815 added in his API changes commit. 

This new templating method requires adding new `.html` files directly to a "template" definition in `models/templates.go`. This allows for defining different templates with the same defined name. 

Template sections are now, for the most part, defined using `define`. `define` does not immediately execute the template's HTML, adding it into the templates output. It defines a composable component which can be added into another section using `{{ template "name" .}}` or `{{ block "name" .}} default content {{ end }}`.