### PR TITLE
cleanup search route

### DIFF
--- a/models/filter.go
+++ b/models/filter.go
@@ -1,0 +1,13 @@
+package models
+
+import "net/url"
+
+func UrlValuesToFilters(vals url.Values) (filters []Filter) {
+	for name, selected := range vals {
+		filters = append(filters, Filter{
+			Name: name,
+			SelectedFilters: selected,
+		})
+	}
+	return
+}

--- a/routes/search.go
+++ b/routes/search.go
@@ -70,38 +70,29 @@ func Search(c echo.Context, db_querier *db.Queries) error {
 
 	if target == "root" || target == "" {
 		return c.Render(http.StatusOK, "search-standalone", urlData)
-	} else if target == "results-container" {
-		if len(filterList) == 0 {
-			results, err := getResults(c, db_querier, query, filters, num)
-			if err != nil {
-				return err
-			}
-			return c.Render(http.StatusOK, "results", results)
-		} 
-		tempResults := models.MakeQuery(query, nil, 1)
-		results, err := getResults(c, db_querier, query, filters, num)
-		if err != nil {
-			return err
-		}
-		results.Filters = tempResults.Filters
-		selectFilters(filters, &results)
-		return c.Render(http.StatusOK, "results", results)
-	} else if target == "results-content-container" {
-		results, err := getResults(c, db_querier, query, filters, num)
-		if err != nil {
-			return err
-		}
-		return c.Render(http.StatusOK, "results-container", results)
-	} else if target == "results-and-pagination" {
-		results, err := getResults(c, db_querier, query, filters, num)
-		if err != nil {
-			return err
-		}
-		return c.Render(http.StatusOK, "results-and-pagination", results)
-	} else {
-		return c.Render(http.StatusOK, "search", urlData)
 	}
 
+	results, err := getResults(c, db_querier, query, filters, num)
+	if err != nil {
+		return err
+	}
+	switch target {
+	case "results-container":
+		if len(filterList) != 0 {
+			tempResults := models.MakeQuery(query, nil, 1)
+			results.Filters = tempResults.Filters
+
+			selectFilters(filters, &results)
+		}
+
+		return c.Render(http.StatusOK, "results", results)
+	case "results-content-container":
+		return c.Render(http.StatusOK, "results-container", results)
+	case "results-and-pagination":
+		return c.Render(http.StatusOK, "results-and-pagination", results)
+	default:
+		return c.Render(http.StatusOK, "search", urlData)
+	}
 }
 
 func getResults(c echo.Context, queries *db.Queries, query string, filters url.Values, num int) (models.KendraResults, error) {


### PR DESCRIPTION
Clean up the search route. Currently, there are a lot of structs being used to pass around data, and some consolidation needs to occur. So far I have just reorganized the route rendering logic, but I plan on cleaning up the data parsing from the search and cleaning the structs used.