### PR TITLE
fix extra searchbar

### DIFF
--- a/web/components/results.templ
+++ b/web/components/results.templ
@@ -14,7 +14,7 @@ templ ResultsPage(results awskendra.KendraResults, isAuthorized bool) {
 			@ResultsAndPagination(results, isAuthorized)
 		</div>
 	</div>
-	@Searchbar(results.UrlData, isAuthorized)
+	@Searchbar(results.UrlData, true)
 	@suggestions_container(true)
 }
 

--- a/web/components/results_templ.go
+++ b/web/components/results_templ.go
@@ -56,7 +56,7 @@ func ResultsPage(results awskendra.KendraResults, isAuthorized bool) templ.Compo
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Searchbar(results.UrlData, isAuthorized).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Searchbar(results.UrlData, true).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
remove the extra searchbar that was shown after completing a search while logged out. The searchbar which was returned OOB was not being sent as OOB when the user is logged out, causing it to be appended to the body of the request and not swapped in by HTMX when received.